### PR TITLE
Remove call to logging.basicConfig

### DIFF
--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -15,7 +15,6 @@ from typing import Callable, Dict, Union
 
 import certifi
 
-logging.basicConfig(level=os.environ.get("LOGLEVEL", "WARNING"))
 logger = logging.getLogger(__name__)
 
 _PLAYSOUND_DEFAULT_BACKEND: Callable[[str], None]

--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -1,7 +1,6 @@
 import atexit
 import ctypes
 import logging
-import os
 import platform
 import ssl
 import subprocess


### PR DESCRIPTION
This PR removes the line `logging.basicConfig(level=os.environ.get("LOGLEVEL", "WARNING"))`, which sets the log level for all calling code. This line makes sense in an application context, but less so in a library, where many different logging configurations could be needed.

For example:
```py
from pathlib import Path
from playsound3 import playsound

logger = logging.getLogger(__name__)

def play_bytes(filepath: Path) -> None:
    logger.info("Playing audio from %s", filepath)
    playsound(filepath)
```

In this example, we attempt to log the filepath to the audio file being played. However, on import `playsound3` updates our logging config and only log levels warning and up are logged.

If in the file calling `play_bytes` we had run `logging.basicConfig(level=logging.INFO, handlers=handlers, format=log_format)` this `basicConfig` would have been overriden.