### PR TITLE
dev dependencies

### DIFF
--- a/.github/workflows/check-with-pytest-linux.yaml
+++ b/.github/workflows/check-with-pytest-linux.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ Home = "https://github.com/sjmikler/playsound3"
 Issues = "https://github.com/sjmikler/playsound3/issues"
 Documentation = "https://github.com/sjmikler/playsound3/blob/main/README.md#quick-start"
 
+[project.optional-dependencies]
+dev = [
+    "pyright",
+    "pytest",
+    "ruff",
+]
+
 [tool.hatch.version]
 path = "playsound3/__init__.py"
 


### PR DESCRIPTION
This change is related to #15


It can take a while to understand what dependencies a developer needs to run the tests. Added a reference to dev dependencies. 

To install dependencies and run tests...

```
pip install .[dev]
cd playsound3
pytest
```
