### PR TITLE
Remove support for EOL Python versions

### DIFF
--- a/.github/workflows/check-with-pytest-linux.yaml
+++ b/.github/workflows/check-with-pytest-linux.yaml
@@ -2,9 +2,9 @@ name: install locally and run pytest on Linux
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Start PulseAudio server

--- a/.github/workflows/check-with-pytest-windows.yaml
+++ b/.github/workflows/check-with-pytest-windows.yaml
@@ -8,9 +8,9 @@ name: install locally and run pytest on Windows
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -12,13 +12,7 @@ import urllib.request
 from abc import ABC, abstractmethod
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any
-
-try:
-    from typing import Protocol
-except ImportError:
-    # Python 3.7 compatibility
-    from typing_extensions import Protocol
+from typing import Any, Protocol
 
 from playsound3 import backends
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "playsound3"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     { name = "Szymon Mikler", email = "sjmikler@gmail.com" },
     { name = "Taylor Marks", email = "taylor@marksfam.com" },
@@ -22,8 +22,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,7 +35,6 @@ classifiers = [
 ]
 dependencies = [
     "pywin32; sys_platform == 'win32'",
-    "typing-extensions; python_version < '3.8'",
 ]
 
 [project.urls]


### PR DESCRIPTION
https://devguide.python.org/versions/

Commit stops supporting EOL python versions, even the typing tools are currently set to 3.9+, and 3.9 is the oldest supported release (for another week, anyway, then it's 3.10).

People stuck on EOL Python versions are able to continue using older playsound3 releases.