### PR TITLE
Handle ffplay check returning non-zero exit statuses

### DIFF
--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -180,7 +180,7 @@ class Ffplay(SoundBackend):
         try:
             subprocess.run(["ffplay", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
             return True
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             return False
 
     def play(self, sound: str) -> subprocess.Popen[str]:


### PR DESCRIPTION
calling ffplay with subprocess can return non-zero exit statuses, causing the current configuration to raise an unhandled exception. This PR simply adds the exception to return the check as false.